### PR TITLE
Check for ammo before reloading gun with CLIP reload type.

### DIFF
--- a/src/main/java/net/dmulloy2/swornguns/types/Gun.java
+++ b/src/main/java/net/dmulloy2/swornguns/types/Gun.java
@@ -147,7 +147,7 @@ public class Gun implements Cloneable
 						clipRemaining = clipSize;
 
 					clipRemaining--;
-					if (clipRemaining <= 0)
+					if (clipRemaining <= 0 && owner.checkAmmo(this, 1))
 					{
 						owner.removeAmmo(this, 1);
 						reloadGun();


### PR DESCRIPTION
This should probably fix #31: "Additionally, when you run out a clips the total ammo becomes negative and you can fire infinitely."